### PR TITLE
Scm 775 - Syntax errors

### DIFF
--- a/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/add/JazzAddCommand.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/add/JazzAddCommand.java
@@ -155,7 +155,7 @@ public class JazzAddCommand
         JazzScmCommand command = createAddCommand( repo, fileSet );
 
         int status = command.execute( addConsumer, errConsumer );
-        if ( status != 0 || errConsumer.hasBeenFed() )
+        if ( status != 0 )
         {
             return new AddScmResult( command.getCommandString(),
                                      "Error code for Jazz SCM add (checkin) command - " + status,

--- a/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/blame/JazzBlameCommand.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/blame/JazzBlameCommand.java
@@ -71,7 +71,7 @@ public class JazzBlameCommand
         ErrorConsumer errConsumer = new ErrorConsumer( getLogger() );
 
         int status = blameCmd.execute( blameConsumer, errConsumer );
-        if ( status != 0 || errConsumer.hasBeenFed() )
+        if ( status != 0 )
         {
             return new BlameScmResult( blameCmd.getCommandString(), "Error code for Jazz SCM blame command - " + status,
                                        errConsumer.getOutput(), false );

--- a/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/changelog/JazzChangeLogCommand.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/changelog/JazzChangeLogCommand.java
@@ -93,7 +93,7 @@ public class JazzChangeLogCommand
         JazzHistoryConsumer changeLogConsumer = new JazzHistoryConsumer( repo, getLogger(), changeSets );
         ErrorConsumer errConsumer = new ErrorConsumer( getLogger() );
         int status = historyCommand.execute( changeLogConsumer, errConsumer );
-        if ( status != 0 || errConsumer.hasBeenFed() )
+        if ( status != 0 )
         {
             return new ChangeLogScmResult( historyCommand.getCommandString(),
                                            "Error code for Jazz SCM history command - " + status,
@@ -106,7 +106,7 @@ public class JazzChangeLogCommand
             new JazzListChangesetConsumer( repo, getLogger(), changeSets, datePattern );
         errConsumer = new ErrorConsumer( getLogger() );
         status = listChangesetsCommand.execute( listChangesetConsumer, errConsumer );
-        if ( status != 0 || errConsumer.hasBeenFed() )
+        if ( status != 0 )
         {
             return new ChangeLogScmResult( listChangesetsCommand.getCommandString(),
                                            "Error code for Jazz SCM list changesets command - " + status,

--- a/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/checkin/JazzCheckInCommand.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/checkin/JazzCheckInCommand.java
@@ -109,7 +109,7 @@ public class JazzCheckInCommand
         ErrorConsumer errConsumer = new ErrorConsumer( getLogger() );
 
         int status = createChangesetCmd.execute( outputConsumer, errConsumer );
-        if ( status != 0 || errConsumer.hasBeenFed() )
+        if ( status != 0 )
         {
             return new CheckInScmResult( createChangesetCmd.getCommandString(),
                                          "Error code for Jazz SCM create changeset command - " + status,
@@ -176,7 +176,7 @@ public class JazzCheckInCommand
             ErrorConsumer errConsumer = new ErrorConsumer( getLogger() );
 
             int status = deliverCmd.execute( deliverConsumer, errConsumer );
-            if ( status != 0 || errConsumer.hasBeenFed() )
+            if ( status != 0 )
             {
                 return new CheckInScmResult( deliverCmd.getCommandString(),
                                              "Error code for Jazz SCM deliver command - " + status,

--- a/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/checkin/JazzCheckInCommand.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/checkin/JazzCheckInCommand.java
@@ -142,7 +142,7 @@ public class JazzCheckInCommand
                     errConsumer = new ErrorConsumer( getLogger() );
         
                     status = changesetAssociateCmd.execute( outputConsumer, errConsumer );
-                    if ( status != 0 || errConsumer.hasBeenFed() )
+                    if ( status != 0  )
                     {
                         return new CheckInScmResult( changesetAssociateCmd.getCommandString(),
                                                      "Error code for Jazz SCM changeset associate command - " + status,

--- a/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/checkout/JazzCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/checkout/JazzCheckOutCommand.java
@@ -72,7 +72,7 @@ public class JazzCheckOutCommand
         ErrorConsumer errConsumer = new ErrorConsumer( getLogger() );
 
         int status = checkoutCmd.execute( checkoutConsumer, errConsumer );
-        if ( status != 0 || errConsumer.hasBeenFed() )
+        if ( status != 0 )
         {
             return new CheckOutScmResult( checkoutCmd.getCommandString(),
                                           "Error code for Jazz SCM checkout (load) command - " + status,

--- a/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/diff/JazzDiffCommand.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/diff/JazzDiffCommand.java
@@ -138,7 +138,7 @@ public class JazzDiffCommand
                 ErrorConsumer errConsumer = new ErrorConsumer( getLogger() );
                 diffCmd = createDiffCommand( repo, fileSet, relativePath );
                 int status = diffCmd.execute( diffConsumer, errConsumer );
-                if ( status != 0 || errConsumer.hasBeenFed() )
+                if ( status != 0 )
                 {
                     // Return a false result (not the usual SCMResult)
                     return new DiffScmResult( diffCmd.toString(), "The scm diff command failed.",

--- a/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/edit/JazzEditCommand.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/edit/JazzEditCommand.java
@@ -78,7 +78,7 @@ public class JazzEditCommand
         JazzScmCommand editCmd = createEditCommand( repo, fileSet );
         int status = editCmd.execute( editConsumer, errConsumer );
 
-        if ( status != 0 || errConsumer.hasBeenFed() )
+        if ( status != 0 )
         {
             return new EditScmResult( editCmd.getCommandString(), "Error code for Jazz SCM edit command - " + status,
                                       errConsumer.getOutput(), false );

--- a/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/list/JazzListCommand.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/list/JazzListCommand.java
@@ -65,7 +65,7 @@ public class JazzListCommand
 
         JazzScmCommand listCmd = createListCommand( jazzRepo, fileSet, recursive, version );
         int status = listCmd.execute( listConsumer, errConsumer );
-        if ( status != 0 || errConsumer.hasBeenFed() )
+        if ( status != 0 )
         {
             return new ListScmResult( listCmd.getCommandString(), "Error code for Jazz SCM list command - " + status,
                                       errConsumer.getOutput(), false );

--- a/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/status/JazzStatusCommand.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/status/JazzStatusCommand.java
@@ -61,7 +61,7 @@ public class JazzStatusCommand
 
         JazzScmCommand statusCmd = createStatusCommand( repo, fileSet );
         int status = statusCmd.execute( statusConsumer, errConsumer );
-        if ( status != 0 || errConsumer.hasBeenFed() )
+        if ( status != 0 )
         {
             return new StatusScmResult( statusCmd.getCommandString(),
                                         "Error code for Jazz SCM status command - " + status, errConsumer.getOutput(),

--- a/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/tag/JazzTagCommand.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/tag/JazzTagCommand.java
@@ -89,7 +89,7 @@ public class JazzTagCommand
             createTagCreateSnapshotCommand( jazzRepo, fileSet, tag, scmTagParameters );
         int status = tagCreateSnapshotCmd.execute( tagConsumer, errConsumer );
 
-        if ( status != 0 || errConsumer.hasBeenFed() )
+        if ( status != 0 )
         {
             return new TagScmResult( tagCreateSnapshotCmd.getCommandString(),
                                      "Error code for Jazz SCM tag (SNAPSHOT) command - " + status,
@@ -104,7 +104,7 @@ public class JazzTagCommand
         errConsumer = new ErrorConsumer( getLogger() );
         status = tagCreateWorkspaceCmd.execute( tagConsumer, errConsumer );
 
-        if ( status != 0 || errConsumer.hasBeenFed() )
+        if ( status != 0 )
         {
             return new TagScmResult( tagCreateWorkspaceCmd.getCommandString(),
                                      "Error code for Jazz SCM tag (WORKSPACE) command - " + status,
@@ -122,7 +122,7 @@ public class JazzTagCommand
             JazzScmCommand tagDeliverCommand = createTagDeliverCommand( jazzRepo, fileSet, tag );
             errConsumer = new ErrorConsumer( getLogger() );
             status = tagDeliverCommand.execute( tagConsumer, errConsumer );
-            if ( status != 0 || errConsumer.hasBeenFed() )
+            if ( status != 0 )
             {
                 return new TagScmResult( tagDeliverCommand.getCommandString(),
                                          "Error code for Jazz SCM deliver command - " + status, errConsumer.getOutput(),
@@ -134,7 +134,7 @@ public class JazzTagCommand
             JazzScmCommand tagSnapshotPromoteCommand = createTagSnapshotPromoteCommand( jazzRepo, fileSet, tag );
             errConsumer = new ErrorConsumer( getLogger() );
             status = tagSnapshotPromoteCommand.execute( tagConsumer, errConsumer );
-            if ( status != 0 || errConsumer.hasBeenFed() )
+            if ( status != 0 )
             {
                 return new TagScmResult( tagSnapshotPromoteCommand.getCommandString(),
                                          "Error code for Jazz SCM snapshot promote command - " + status,

--- a/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/unedit/JazzUnEditCommand.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/unedit/JazzUnEditCommand.java
@@ -78,7 +78,7 @@ public class JazzUnEditCommand
         JazzScmCommand uneditCmd = createUneditCommand( repo, fileSet );
         int status = uneditCmd.execute( uneditConsumer, errConsumer );
 
-        if ( status != 0 || errConsumer.hasBeenFed() )
+        if ( status != 0 )
         {
             return new UnEditScmResult( uneditCmd.getCommandString(),
                                         "Error code for Jazz SCM unedit command - " + status, errConsumer.getOutput(),

--- a/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/update/JazzUpdateCommand.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/update/JazzUpdateCommand.java
@@ -69,12 +69,12 @@ public class JazzUpdateCommand
         }
 
         JazzUpdateConsumer updateConsumer = new JazzUpdateConsumer( repo, getLogger() );
-        ErrorConsumer err = new ErrorConsumer( getLogger() );
+        ErrorConsumer errConsumer = new ErrorConsumer( getLogger() );
 
         JazzScmCommand updateCmd = createAcceptCommand( repo, fileSet );
-        int status = updateCmd.execute( updateConsumer, err );
+        int status = updateCmd.execute( updateConsumer, errConsumer );
 
-        if ( status != 0 || err.hasBeenFed() )
+        if ( status != 0 )
         {
             return new UpdateScmResult( updateCmd.getCommandString(),
                                         "Error code for Jazz SCM update command - " + status, err.getOutput(), false );

--- a/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/update/JazzUpdateCommand.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/update/JazzUpdateCommand.java
@@ -77,7 +77,8 @@ public class JazzUpdateCommand
         if ( status != 0 )
         {
             return new UpdateScmResult( updateCmd.getCommandString(),
-                                        "Error code for Jazz SCM update command - " + status, err.getOutput(), false );
+                                        "Error code for Jazz SCM update command - " + status, 
+                                        errConsumer.getOutput(), false );
         }
 
         if ( getLogger().isDebugEnabled() )

--- a/maven-scm-providers/maven-scm-provider-jazz/src/test/java/org/apache/maven/scm/provider/jazz/command/JazzTckUtil.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/test/java/org/apache/maven/scm/provider/jazz/command/JazzTckUtil.java
@@ -92,7 +92,7 @@ public class JazzTckUtil
             createCreateWorkspaceFromSnapshotCommand( jazzRepo, fileSet, nameWorkspace, nameSnapshot );
         int status = tckCreateWorkspaceFromSnapshotCmd.execute( tckConsumer, errConsumer );
 
-        if ( status != 0 || errConsumer.hasBeenFed() )
+        if ( status != 0 )
         {
             return new ScmResult( tckCreateWorkspaceFromSnapshotCmd.getCommandString(),
                                   "Error code for Jazz SCM (create workspace --snapshot) command - " + status,

--- a/maven-scm-providers/maven-scm-provider-jazz/src/test/java/org/apache/maven/scm/provider/jazz/command/status/JazzStatusCommandTest.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/test/java/org/apache/maven/scm/provider/jazz/command/status/JazzStatusCommandTest.java
@@ -232,7 +232,6 @@ public class JazzStatusCommandTest
     {
     	statusConsumer.consumeLine( "Workspace: (1000) \"GPDBWorkspace\" <-> (1001) \"GPDBStream\"" );
     	statusConsumer.consumeLine( "  Component: (1002) \"GPDB\"" );
-    	statusConsumer.consumeLine( "    Baseline: (1003) 49 \"GPDB-MAN-1.0.50\"" );
     	statusConsumer.consumeLine( "    Unresolved:" );
     	statusConsumer.consumeLine( "      a-- /GPDB/GPDBEAR/pom.xml.releaseBackup" );
     	statusConsumer.consumeLine( "      a-- /GPDB/GPDBResources/pom.xml.releaseBackup" );
@@ -254,6 +253,7 @@ public class JazzStatusCommandTest
     			+ "release of GPDB-1.0.51\" 02-May-2015 07:54 PM" );
     	statusConsumer.consumeLine( "        (1006) ---@  \"[maven-release-plugin] prepare "
     			+ "release GPDB-1.0.51\" 02-May-2015 09:33 PM" );
+        statusConsumer.consumeLine( "    Baseline: (1003) 49 \"GPDB-MAN-1.0.50\"" );
 
         // Test the additional collected data, Workspace, Component, Baseline.
         assertEquals( "Workspace is incorrect!", "GPDBWorkspace", repo.getWorkspace() );


### PR DESCRIPTION
Possibly not a true pull request as I've merged in the fix for SCM-795 here as well.
But especially a syntax fix for 2 files in commit db8a2703334a02283cc407bb2f708ebd8719bcaf,

Updated  JazzStatusCommand to provide a reset ability for the state machine when looking for change sets
